### PR TITLE
Fix host server_name mixup

### DIFF
--- a/app/app_config.py
+++ b/app/app_config.py
@@ -20,7 +20,6 @@ class AppConfig(object):
     SQLALCHEMY_DATABASE_URI = settings.DATABASE_URL
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     SQLALCHEMY_ECHO = False
-    SERVER_NAME = settings.HOST
 
 
 def init_app(app):

--- a/config/settings.py
+++ b/config/settings.py
@@ -92,4 +92,4 @@ APNS_APP_BUNDLE_ID = get_env_default('APNS_APP_BUNDLE_ID')
 FCM_API_KEY = get_env_default('FCM_API_KEY')
 FCM_TITLE = get_env_default('FCM_TITLE')
 
-BIND_HOST = parse_bool(get_env_default("BIND_HOST"))
+BIND_HOST = get_env_default("BIND_HOST")

--- a/dev.env
+++ b/dev.env
@@ -1,6 +1,9 @@
 DEBUG=1
+# HOST is currently used for absolut urls for example on return urls from oath
+# BIND_HOST is the host that flask is binding to when running as it's only server
+# BIND_HOST is ignored when running under waitress-serve
 HOST=localhost:5000
-BIND_HOST=0
+BIND_HOST=0.0.0.0:5000
 HTTPS=0
 FLASK_SECRET_KEY=dev-secret-key
 DATABASE_URL=postgresql://localhost/bridge-server

--- a/main.py
+++ b/main.py
@@ -16,8 +16,8 @@ if __name__ == '__main__':
     host = None
     port = None
     if settings.BIND_HOST:
-        if ':' in settings.HOST:
-            host, port_str = settings.HOST.split(':')
+        if ':' in settings.BIND_HOST:
+            host, port_str = settings.BIND_HOST.split(':')
             port = int(port_str)
         else:
             host = settings.HOST


### PR DESCRIPTION
First pull request? Read our [guide to contributing](http://docs.originprotocol.com/#contributing)

### Checklist:

- [X] Code has been formatted with `autopep8 --in-place --recursive --a --a .`
- [X] Ensure all new and existing tests pass
- [X] Update any relevant READMEs and [docs](https://github.com/OriginProtocol/docs)
- [X] Submit to the `develop` branch instead of `master`

### Description:

- There's a mix up on my part of what SERVER_NAME and HOST does for flask. Currently we are using HOST for absurls and not for enforcement of routes and cookie setting.